### PR TITLE
SSL cookbook example did not work for me.

### DIFF
--- a/cookbook/ssl.md
+++ b/cookbook/ssl.md
@@ -14,11 +14,14 @@ How to set SSL support in built-in cherrypy server web.py
 ## Solution
 
     import web
-    
     from web.wsgiserver import CherryPyWSGIServer
+    from web.wsgiserver.ssl_builtin import BuiltinSSLAdapter
+    
+    ssl_cert = "path/to/ssl_certificate"
+    ssl_key = "path/to/ssl_private_key"
+    
+    CherryPyWSGIServer.ssl_adapter = BuiltinSSLAdapter(ssl_cert,ssl_key,None)
 
-    CherryPyWSGIServer.ssl_certificate = "path/to/ssl_certificate"
-    CherryPyWSGIServer.ssl_private_key = "path/to/ssl_private_key"
 
     urls = ("/.*", "hello")
     app = web.application(urls, globals())


### PR DESCRIPTION
 After many hours of sifting through source, I came up with this way.

You must install cherrypy for this way to work.

I'm not sure why the other way doesn't work for me, but even copy/pasting the example code verbatim did not work. The server only responded to http requests and the browser gave an "ssl error" when explicitly navigating to an https url.
