### PR TITLE
The method I proposed in an earlier commit does not handle SSLExceptions...

### DIFF
--- a/cookbook/ssl.md
+++ b/cookbook/ssl.md
@@ -11,7 +11,24 @@ Other languages: [français](/../cookbook/ssl/fr) | ...
 
 How to set SSL support in built-in cherrypy server web.py
 
-## Solution
+## Solution (Requires latest web.py version [0.37 installed from source as of this writing])
+    import web
+    from web.wsgiserver import CherryPyWSGIServer
+    
+    CherryPyWSGIServer.ssl_certificate = "/path/to/ssl_certificate"
+    CherryPyWSGIServer.ssl_private_key = "/path/to/ssl_private_key"
+       
+    urls = ("/.*", "hello")
+    app = web.application(urls, globals())
+
+    class hello:
+        def GET(self):
+            return 'Hello, world!'
+
+    if __name__ == "__main__":
+        app.run()
+
+## For version 0.36 and earlier (somewhat broken implementation, will crash on SSLException)
 
     import web
     from web.wsgiserver import CherryPyWSGIServer


### PR DESCRIPTION
... well (crashes the entire server when this happens). The solution is to upgrade the version of web.py you're using to the latest source instead of the older version installed via easy_install. With the new (fixed) web.py source, you can enable SSL as in the initial cookbook page.

Sorry for any confusion. This was a confusing issue to solve :)
