### PR TITLE
docs/0.3/tutorial removed indentation before "raise web.seeother('/')

### DIFF
--- a/docs/0.3/tutorial.md
+++ b/docs/0.3/tutorial.md
@@ -225,7 +225,7 @@ Now add another class:
         def POST(self):
             i = web.input()
             n = db.insert('todo', title=i.title)
-    	        raise web.seeother('/')
+    	    raise web.seeother('/')
 
 (Notice how we're using `POST` for this?)
 


### PR DESCRIPTION
I am new to almost all of this--first pull request on github, just started web.py today, working through Learn Python the Hard Way.

In anycase, I think I am correct that the indentation before "raise web.seeother('/') is a typo in the tutorial.  In my own code, I needed to put it in line with n = ... and that also makes sense to me.  Hope I'm right and this helps!
