### PR TITLE
fixed formatting on template_tricks.md

### DIFF
--- a/template_tricks.md
+++ b/template_tricks.md
@@ -10,9 +10,11 @@ title: template tricks
 Test the rendering of a template.py template
 
         def renderTemplate(templatename,*args,**kw):
-            '''quick way to test a template.py template'''            import template
+            '''quick way to test a template.py template'''            
+            import template
             if not "." in templatename:
-                templatename = templatename + ".tmpl"            obj = template.Template(open(templatename).read())
+                templatename = templatename + ".tmpl"            
+                obj = template.Template(open(templatename).read())
             return obj(*args,**kw)
 
         print renderTemplate("homepage", now=time.ctime())
@@ -20,7 +22,9 @@ Test the rendering of a template.py template
 If your template takes a dict or a storage, then you can just
 set global values and let those get passed in:
 
-        username = "User"        lastvisit = "yesterday"        print renderTemplate("results", store=web.Storage(globals()))
+        username = "User"        
+        lastvisit = "yesterday"        
+        print renderTemplate("results", store=web.Storage(globals()))
 
 ---
 


### PR DESCRIPTION
currently, it's showing up without linefeeds on webpy.org
I fixed it so it looks like what I think is correct
I'm using gedit with "replace tabs with spaces", so I'm not sure
why my previous commit had messed-up tabs/spaces. Let me know how
to do it better for next time.
