### PR TITLE
improvements to fastcgi-apache.md

### DIFF
--- a/cookbook/fastcgi-apache.md
+++ b/cookbook/fastcgi-apache.md
@@ -7,7 +7,7 @@ title: Web.py using FastCGI and Apache 2
 
 #Requirements
 * Apache 2.x
-* [mod_fcgid](http://httpd.apache.org/mod_fcig/)
+* [mod_fcgid](http://httpd.apache.org/mod_fcgid/)
 * [mod_rewrite](http://httpd.apache.org/docs/2.0/rewrite/)
 * [Flup](http://trac.saddi.com/flup)
 


### PR DESCRIPTION
1. Changed broken link for mod_fcgid
2. At bottom of page, added a link to hack for getting page to work using Apache hosted on bluehost.com

Not sure if you want #2 addition.  The code works, but I don't know what I'm doing, so there may be serious flaws in it.  But I couldn't find help elsewhere to get web.py working with Apache when you don't have root access.
