### PR TITLE
Updated SQL Alchemy Hook

### DIFF
--- a/cookbook/sqlalchemy.md
+++ b/cookbook/sqlalchemy.md
@@ -18,6 +18,7 @@ create a load hook and use sqlalchemy's [scoped session] (http://docs.sqlalchemy
     import random
     import web
 
+    from sqlalchemy.exc import OperationalError
     from sqlalchemy.orm import scoped_session, sessionmaker
     from models import *
 
@@ -33,8 +34,12 @@ create a load hook and use sqlalchemy's [scoped session] (http://docs.sqlalchemy
         
         try:
             return handler()
-        except:
+        except OperationalError:
             web.ctx.orm.rollback()
+            Session.remove()
+            raise
+        except:
+            web.ctx.orm.commit()
             Session.remove()
             raise
         finally:


### PR DESCRIPTION
The updated version follows the documentation for scoped sessions
in context of web applications. The old approach fails, if engine
connections are invalidated (e.g. MySql Server Timeout or Restart).
There might be some open, uncommitted sessions, that prevent the
engine from refreshing the connection pool. Using the scoped_session
as in this update and recommended in the latest docs fixes the
problem.
