### PR TITLE
Fixed links to French translations

### DIFF
--- a/cookbook/application_processors.md
+++ b/cookbook/application_processors.md
@@ -5,7 +5,7 @@ title: Application processors, hooks
 
 # Application processors, hooks
 
-Other languages : [français](/../cookbook/application_processors/fr) | ...
+Other languages : [français](/../cookbook/application_processors.fr) | ...
 
 ##  Problem
 

--- a/cookbook/cookies.md
+++ b/cookbook/cookies.md
@@ -5,7 +5,7 @@ title: cookies
 
 # cookies
 
-Other languages: [français](/../cookbook/cookies/fr) | ...
+Other languages: [français](/../cookbook/cookies.fr) | ...
 
 ##Problem
 You want to set and retrieve cookies for a user browsing the site.

--- a/cookbook/ctx.md
+++ b/cookbook/ctx.md
@@ -5,7 +5,7 @@ title: ctx
 
 # ctx
 
-Other languages: [français](/../cookbook/ctx/fr) | ...
+Other languages: [français](/../cookbook/ctx.fr) | ...
 
 Problem
 -------

--- a/cookbook/custom_notfound.md
+++ b/cookbook/custom_notfound.md
@@ -5,7 +5,7 @@ title: Custom NotFound message
 
 # Custom NotFound message
 
-Other languages:  [français](/../cookbook/custom_notfound/fr) | ...
+Other languages:  [français](/../cookbook/custom_notfound.fr) | ...
 
 ## Problem
 

--- a/cookbook/fastcgi-lighttpd.md
+++ b/cookbook/fastcgi-lighttpd.md
@@ -5,7 +5,7 @@ title: Webpy + LightTTPD with FastCGi
 
 # Webpy + LightTTPD with FastCGi
 
-Other languages: [français](/../cookbook/fastcgi-lighttpd/fr) | ...
+Other languages: [français](/../cookbook/fastcgi-lighttpd.fr) | ...
 
 *If you have problems with this recipe read this [thread](http://www.mail-archive.com/webpy@googlegroups.com/msg02800.html)*
 

--- a/cookbook/fileupload.md
+++ b/cookbook/fileupload.md
@@ -5,7 +5,7 @@ title: File Upload Recipe
 
 # File Upload Recipe
 
-Other languages: [français](/../cookbook/fileupload/fr) | ...
+Other languages: [français](/../cookbook/fileupload.fr) | ...
 
 ## Problem
 

--- a/cookbook/forms.md
+++ b/cookbook/forms.md
@@ -5,7 +5,7 @@ title: How to use forms
 
 # How to use forms
 
-Other languages: [français](/../cookbook/forms/fr) | ...
+Other languages: [français](/../cookbook/forms.fr) | ...
 
 ## Problem
 

--- a/cookbook/helloworld.md
+++ b/cookbook/helloworld.md
@@ -5,7 +5,7 @@ title: Hello World!
 
 # Hello World!
 
-Other languages : [français](/helloworld/fr) | ...
+Other languages : [français](/helloworld.fr) | ...
 
 ## Problem
 

--- a/cookbook/input.md
+++ b/cookbook/input.md
@@ -5,7 +5,7 @@ title: web.input
 
 # web.input
 
-Other languages: [français](/../cookbook/input/fr) | ...
+Other languages: [français](/../cookbook/input.fr) | ...
 
 ##web.input
 

--- a/cookbook/layout_template.md
+++ b/cookbook/layout_template.md
@@ -5,7 +5,7 @@ title: Site Layout Template
 
 # Site Layout Template
 
-Other languages : [français](/layout_template/fr) | ...
+Other languages : [français](/layout_template.fr) | ...
 
 ### Problem
 

--- a/cookbook/limiting_upload_size.md
+++ b/cookbook/limiting_upload_size.md
@@ -5,7 +5,7 @@ title: How to put a limit on upload size
 
 # How to put a limit on upload size
 
-Other languages: [français](/../cookbook/limiting_upload_size/fr) | ...
+Other languages: [français](/../cookbook/limiting_upload_size.fr) | ...
 
 ## Problem
 

--- a/cookbook/logging.md
+++ b/cookbook/logging.md
@@ -5,7 +5,7 @@ title: Logging
 
 # Logging
 
-Other languages: [français](/../cookbook/logging/fr) | ...
+Other languages: [français](/../cookbook/logging.fr) | ...
 
 ## Problem:
 

--- a/cookbook/postbasic.md
+++ b/cookbook/postbasic.md
@@ -5,7 +5,7 @@ title: Reading raw data from post
 
 # Reading raw data from post
 
-Other languages: [français](/../cookbook/postbasic/fr) | ...
+Other languages: [français](/../cookbook/postbasic.fr) | ...
 
 ## Introduction
 

--- a/cookbook/redirect+seeother.md
+++ b/cookbook/redirect+seeother.md
@@ -5,7 +5,7 @@ title: web.redirect and web.seeother
 
 # web.redirect and web.seeother
 
-Other languages:  [français](/../cookbook/redirect+seeother/fr) | ...
+Other languages:  [français](/../cookbook/redirect+seeother.fr) | ...
 
 ## web.redirect and web.seeother
 

--- a/cookbook/sendmail_using_gmail.md
+++ b/cookbook/sendmail_using_gmail.md
@@ -5,7 +5,7 @@ title: Sending mail using gmail
 
 # Sending mail using gmail
 
-Other languages: [français](/../cookbook/sendmail_using_gmail/fr) | ...
+Other languages: [français](/../cookbook/sendmail_using_gmail.fr) | ...
 
 ##Problem: 
 

--- a/cookbook/session_in_template.md
+++ b/cookbook/session_in_template.md
@@ -5,7 +5,7 @@ title: Using session in template
 
 # Using session in template
 
-Other languages: [français](/../cookbook/session_in_template/fr) | ...
+Other languages: [français](/../cookbook/session_in_template.fr) | ...
 
 ##Problem: 
 

--- a/cookbook/session_with_reloader.md
+++ b/cookbook/session_with_reloader.md
@@ -5,7 +5,7 @@ title: Using session with reloader
 
 # Using session with reloader
 
-Other languages: [français](/../cookbook/session_with_reloader/fr) | ...
+Other languages: [français](/../cookbook/session_with_reloader.fr) | ...
 
 # Problem
 

--- a/cookbook/sessions.md
+++ b/cookbook/sessions.md
@@ -5,7 +5,7 @@ title: Sessions
 
 # Sessions
 
-Other languages: [français](/../cookbook/sessions/fr) | ...
+Other languages: [français](/../cookbook/sessions.fr) | ...
 
 ### Problem
 

--- a/cookbook/sessions_with_subapp.md
+++ b/cookbook/sessions_with_subapp.md
@@ -5,7 +5,7 @@ title: Sessions with Sub-apps
 
 # Sessions with Sub-apps
 
-Other languages: [français](/../cookbook/sessions_with_subapp/fr) | ...
+Other languages: [français](/../cookbook/sessions_with_subapp.fr) | ...
 
 ###Note
 *This solutions is taken from [this](http://www.mail-archive.com/webpy@googlegroups.com/msg02557.html) post on the web.py mailing list.*

--- a/cookbook/ssl.md
+++ b/cookbook/ssl.md
@@ -5,7 +5,7 @@ title: SSL support in built-in cherrypy server
 
 # SSL support in built-in cherrypy server
 
-Other languages: [français](/../cookbook/ssl/fr) | ...
+Other languages: [français](/../cookbook/ssl.fr) | ...
 
 ## Problem
 

--- a/cookbook/staticfiles.md
+++ b/cookbook/staticfiles.md
@@ -5,7 +5,7 @@ title: Serving Static Files (such as js, css and images)
 
 # Serving Static Files (such as js, css and images)
 
-Other languages : [français](/staticfiles/fr) | ...
+Other languages : [français](/staticfiles.fr) | ...
 
 Problem
 -------

--- a/cookbook/streaming_large_files.md
+++ b/cookbook/streaming_large_files.md
@@ -5,7 +5,7 @@ title: How to Stream Large Files
 
 # How to Stream Large Files
 
-Other languages: [français](/../cookbook/streaming_large_files/fr) | ...
+Other languages: [français](/../cookbook/streaming_large_files.fr) | ...
 
 ## Problem:
 

--- a/cookbook/subapp.md
+++ b/cookbook/subapp.md
@@ -5,7 +5,7 @@ title: using subapplications
 
 # using subapplications
 
-Other languages [français](/../cookbook/subapp/fr) | ...
+Other languages [français](/../cookbook/subapp.fr) | ...
 
 ## Problem
 

--- a/cookbook/url_handling.md
+++ b/cookbook/url_handling.md
@@ -5,7 +5,7 @@ title: Understanding URL Handling
 
 # Understanding URL Handling
 
-Other languages : [français](/../cookbook/url_handling/fr) | ...
+Other languages : [français](/../cookbook/url_handling.fr) | ...
 
 `Problem`: how to design a url handling / dispatching scheme for the entire site
 

--- a/cookbook/userauth.md
+++ b/cookbook/userauth.md
@@ -7,7 +7,7 @@ title: user authentication
 
 #I'm still working on this page, please no body else edit
 
-Other languages : [français](/userauth/fr) | ...
+Other languages : [français](/userauth.fr) | ...
 
 ##Problem
 You want a system to authenticate users.

--- a/cookbook/xmlfiles.md
+++ b/cookbook/xmlfiles.md
@@ -5,7 +5,7 @@ title: Serving XML
 
 # Serving XML
 
-Other languages:  [français](/../cookbook/xmlfiles/fr) | ...
+Other languages:  [français](/../cookbook/xmlfiles.fr) | ...
 
 ### Problem
 


### PR DESCRIPTION
It seems to me that all links to French translations from inside the English articles in Cookbook were wrong -- they had a slash "/" instead of a dot ".", so I changed them.

Also added a newline character at the end of the last line of each document that I edited. This makes the files easier to parse with `grep`.
