### PR TITLE
Typo Fixed: MIME Content Type is image/ not images/

### DIFF
--- a/images.md
+++ b/images.md
@@ -24,13 +24,13 @@ Now create the class that will handle them:
             ext = name.split(".")[-1] # Gather extension
             
             cType = {
-                "png":"images/png",
-                "jpg":"images/jpeg",
-                "gif":"images/gif",
-                "ico":"images/x-icon"            }
+                "png":"image/png",
+                "jpg":"image/jpeg",
+                "gif":"image/gif",
+                "ico":"image/x-icon"            }
 
             if name in os.listdir('images'):  # Security
-                web.header("Content-Type", cType[ext]) # Set the Header
+                web.header("Content-Type", cType[ext.lower()]) # Set the Header
                 return open('images/%s'%name,"rb").read() # Notice 'rb' for reading images
             else:
                 raise web.notfound()


### PR DESCRIPTION
Per RFC 2045, Section 5.1, Content Type is "image" not "images". https://tools.ietf.org/html/rfc2045

Additionally, the ext portion is user-controlled and may not be in lowercase as expected in the cType dictionary.  Added .lower() when called to allow "JPG" and "jpg" to both match the "jpg" lookup for "image/jpeg".

This also addresses the open issue seen here: https://github.com/webpy/webpy/issues/234
