### PR TITLE
Update runtime-language-switch.zh-cn.md

### DIFF
--- a/cookbook/runtime-language-switch.zh-cn.md
+++ b/cookbook/runtime-language-switch.zh-cn.md
@@ -120,7 +120,7 @@ title: 实时语言切换
 你必须:
 
  * 确保语言文件(en_US、zh_CN等)可以动态改变。
- * 确保custom_gettext()调用越省资源约好。
+ * 确保custom_gettext()调用越省资源越好。
 
 参考:
 


### PR DESCRIPTION
文字错误， ”确保custom_gettext()调用越省资源约好“ 改为 "确保custom_gettext()调用越省资源越好"
