### PR TITLE
update index.md web.py examples

### DIFF
--- a/index.md
+++ b/index.md
@@ -42,9 +42,41 @@ Or to get the latest development version from git:
 web.py was originally published while Aaron Swartz worked at [reddit.com][20], where the site used it as it grew to become one of the top 1000 sites according to Alexa and served millions of daily page views. "It's the anti-framework framework. web.py doesn't get in your way," explained founder Steve Huffman. (The site was rewritten using other tools after being acquired by Condé Nast.)
 
    [20]: http://reddit.com/
+### Some user testimonials:
 
-* [Frinki](http://frinki.com), a new social network in Spanish.
+*"In the ecosystem of web frameworks, something must occupy the niche of 'small, light, and fast': web.py does this."*  
+<span class="cite">&nbsp;&nbsp;&mdash;&nbsp; Lloyd Dalton, [colr.org](http://colr.org)</span>
 
+*"We finished rewriting our server in only a fews days with web.py and it was everything we hoped for."*  
+<span class="cite">&nbsp;&nbsp;&mdash;&nbsp; Sam Hsiung, [YouOS][25]</span>
+
+   [25]: http://www.youos.com/
+
+*"[Web.py inspired the] web framework we use at FriendFeed [and] the webapp framework that ships with App Engine..."*  
+<span class="cite">&nbsp;&nbsp;&mdash;&nbsp; [Brett Taylor](http://backchannel.org/blog/google-app-engine), co-founder of FriendFeed and original tech lead on Google App Engine</span>
+
+*"Django lets you write web apps in Django. TurboGears lets you write web apps in TurboGears. Web.py lets you write web apps in Python."*  
+<span class="cite">&nbsp;&nbsp;&mdash;&nbsp; Adam Atlas</span>
+
+*"Guido* [van Rossum, creator of Python]*, you'll probably find that web.py best suits your style. ... If you don't like it, I can't imagine which of the other dozens of frameworks out there you __would__ like."*   
+<span class="cite">&nbsp;&nbsp;&mdash;&nbsp; Phillip J. Eby, creator of the Python Web Server Gateway Interface (WSGI) [#][30]</span>
+
+   [30]: http://www.artima.com/forums/flat.jsp?forum=106&thread=146149&start=30&msRange=15
+   
+### Websites utilizing web.py:
+
+* [colr.org](http://www.colr.org), A site for creating and playing with color schemes with API, powered by web.py.
+   
+* [jottit.com](http://jottit.com) Jottit makes getting a website as easy as filling out a textbox.
+
+* [URIs.us][u] is a service for creating shortened urls. Deployed on Google App Engine.
+
+   [u]: http://uris.us 
+
+* [Biomed Search] [zzz] Use keywords to search through more than one million biomedical images with linked sources.
+
+   [zzz]: http://www.biomed-search.com
+   
 * [Yandex][21], the leading Russian search engine (their homepage alone receives 70 million daily page views).
 
    [21]: http://yandex.ru
@@ -54,20 +86,4 @@ web.py was originally published while Aaron Swartz worked at [reddit.com][20], w
 * [Oyster.com](http://www.oyster.com/), a website that reviews and photographs hotels, uses web.py for the entire site. They note that "web.py gives us the control we need for a large-scale website". As of Jan 2013, Oyster.com renders about 230,000 pages per day.
 
 * [local.ch](http://www.local.ch), the official online Telephone Directory for Switzerland - using web.py in a backend service for tracking expired content - code open-sourced as [urldammit](http://github.com/harryf/urldammit/tree/master).
-
-* [archivd.com](http://www.archivd.com), a web application for collaborative research and archiving, is built on web.py.
-
-* [Chiefmall](http://www.chiefmall.com/), a contractor search tool, was built with web.py.
-
-* [pudung.com](http://pudung.com), Online Store based in Jakarta, Indonesia, is using [onlinestore-multi](https://github.com/nopri/onlinestore-multi) (Simple Online Store application built using Python, web.py, jQuery and MySQL).
-
-"[web.py inspired the] web framework we use at FriendFeed [and] the webapp framework that ships with App Engine..."  
-<span class="cite">&nbsp;&nbsp;&mdash;&nbsp; [Brett Taylor](http://bret.appspot.com/entry/experimenting-google-app-engine), co-founder of FriendFeed and original tech lead on Google App Engine</span>
-
-"Django lets you write web apps in Django. TurboGears lets you write web apps in TurboGears. Web.py lets you write web apps in Python."  
-<span class="cite">&nbsp;&nbsp;&mdash;&nbsp; Adam Atlas</span>
-
-"Guido [van Rossum, creator of Python], you'll probably find that web.py best suits your style. ... If you don't like it, I can't imagine which of the other dozens of frameworks out there you *would* like."   
-<span class="cite">&nbsp;&nbsp;&mdash;&nbsp; Phillip J. Eby, creator of the Python Web Server Gateway Interface (WSGI) [#][30]</span>
-
-   [30]: http://www.artima.com/forums/flat.jsp?forum=106&thread=146149&start=30&msRange=15
+ 


### PR DESCRIPTION
A few brokenLinks/defunctProjects have been removed, some added from the french index.md, and reformatted to put testimonials first as they seem stronger than the website examples shown. Might be nice to eventually add the github projects from the code samples page onto this frontpage, too. I know this isn't getting maintained much but broken links are a bummer so I thought I'd lend a hand for 'those who come after'.
