### PR TITLE
Bump latest version to v0.62

### DIFF
--- a/index.md
+++ b/index.md
@@ -19,7 +19,7 @@ To install the latest web.py for Python 3, please run:
 pip3 install web.py
 ```
 
-The latest `0.61` release supports Python >= 3.5.
+The latest `0.62` release supports Python >= 3.5.
 Version `0.51` is the last release with Python 2.7 support.
 
 ## A minimal web.py application


### PR DESCRIPTION
The website wrongly displays the latest version as v0.61.

This PR bumps the version to v0.62, the latest version as of August 2021.